### PR TITLE
Solve RPC port conflicts with thyme

### DIFF
--- a/dogechia/util/initial-config.yaml
+++ b/dogechia/util/initial-config.yaml
@@ -110,7 +110,7 @@ farmer:
 
   # If True, starts an RPC server at the following port
   start_rpc_server: True
-  rpc_port: 16759
+  rpc_port: 16762
 
   # To send a share to a pool, a proof of space must have required_iters less than this number
   pool_share_threshold: 1000
@@ -298,7 +298,7 @@ introducer:
 
 wallet:
   port: 6883
-  rpc_port: 16761
+  rpc_port: 16763
 
   # The minimum height that we care about for our transactions. Set to zero
   # If we are restoring from private key and don't know the height.


### PR DESCRIPTION
These two new port numbers do not currently conflict with most active chia forks, nor chia itself.